### PR TITLE
Fix the rowHeight for empty rows array

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ class Unendlich {
     this.renderRow = render
     this.updateRow = update
     this.debug = debug
-    this.rowHeight = this.getRowHeight(rows[0])
+    this.rowHeight = rows.length ? this.getRowHeight(rows[0]) : 0
     this.outerHeight = this.outer.offsetHeight
     this.pageRows = page || 100
     this.setRows(rows)


### PR DESCRIPTION
When a view with no rows gets initialised it tries to render a non-existing element to get the row height.